### PR TITLE
Bump Ecto timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,9 @@ config :vidfeeder, VidFeeder.Repo,
   password: "pass",
   hostname: "localhost",
   migration_primary_key: [id: :uuid, type: :binary_id],
-  migration_timestamps: [type: :utc_datetime]
+  migration_timestamps: [type: :utc_datetime],
+  timeout: 60_000,
+  pool_timeout: 60_000
 
 
 # General application configuration


### PR DESCRIPTION
We're currently timing out on large playlists. When we update the
playlist_items list for a given playlist, we use put_assoc, which
performs the update/insert/deletions in a single transaction. If that
step isn't completed before the timeout, `put_assoc` will raise an
exception and the import will fail.

To fix, bump the timeout to a more reasonable amount and re-evaluate if
necessary.