### PR TITLE
Youtube: Enhance RSS view for playlists

### DIFF
--- a/lib/vidfeeder/feed_generator.ex
+++ b/lib/vidfeeder/feed_generator.ex
@@ -39,7 +39,7 @@ defmodule VidFeeder.FeedGenerator do
 
   defp do_generate(%YouTubePlaylist{} = playlist) do
     %Feed{
-      title: playlist.playlist_id,
+      title: playlist.title || playlist.playlist_id,
       description: nil,
       image_url: nil,
       items: generate_items(playlist)

--- a/lib/vidfeeder/youtube_playlist.ex
+++ b/lib/vidfeeder/youtube_playlist.ex
@@ -6,6 +6,9 @@ defmodule VidFeeder.YouTubePlaylist do
   schema "youtube_playlists" do
     field(:playlist_id, :string)
     field(:etag, :string)
+    field(:title, :string)
+    field(:description, :string)
+    field(:image_url, :string)
 
     has_one(:source, VidFeeder.Source, foreign_key: :youtube_playlist_id)
 
@@ -23,12 +26,15 @@ defmodule VidFeeder.YouTubePlaylist do
 
   def api_changeset(youtube_playlist, %YouTube.Playlist{} = playlist) do
     changeset(youtube_playlist, %{
+      title: playlist.title,
+      description: playlist.description,
+      image_url: playlist.image_url,
       etag: playlist.etag
     })
   end
 
   def changeset(playlist, params \\ %{}) do
     playlist
-    |> cast(params, [:etag])
+    |> cast(params, [:title, :description, :etag, :image_url])
   end
 end

--- a/priv/repo/migrations/20190818225328_add_title_to_you_tube_playlist.exs
+++ b/priv/repo/migrations/20190818225328_add_title_to_you_tube_playlist.exs
@@ -1,0 +1,38 @@
+defmodule VidFeeder.Repo.Migrations.AddTitleToYouTubePlaylist do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  alias VidFeeder.{
+    Repo,
+    YouTubePlaylist
+  }
+
+  def up do
+    alter table(:youtube_playlists) do
+      add :title, :string
+      add :description, :string
+      add :image_url, :string
+    end
+
+    flush()
+
+    Repo.transaction(fn ->
+      (from p in YouTubePlaylist)
+      |> Repo.stream
+      |> Enum.each(fn playlist ->
+        playlist
+        |> YouTubePlaylist.changeset(%{etag: nil})
+        |> Repo.update!
+      end)
+    end)
+  end
+
+  def down do
+    alter table(:youtube_playlists) do
+      remove :title
+      remove :description
+      remove :image_url
+    end
+  end
+end


### PR DESCRIPTION
Previously we were not storing the playlist's title on the model. For feeds that were generated directly from a playlist, we would just use the playlist id as the RSS channel title.

We should store and utilize the following fields when generating RSS feeds for playlists:
* title
* description
* image_url