### PR TITLE
YouTube: Use playlist description

### DIFF
--- a/lib/vidfeeder/feed_generator.ex
+++ b/lib/vidfeeder/feed_generator.ex
@@ -40,8 +40,8 @@ defmodule VidFeeder.FeedGenerator do
   defp do_generate(%YouTubePlaylist{} = playlist) do
     %Feed{
       title: playlist.title || playlist.playlist_id,
-      description: nil,
-      image_url: nil,
+      description: playlist.description,
+      image_url: playlist.image_url,
       items: generate_items(playlist)
     }
   end


### PR DESCRIPTION
Follow up to #51

In addition to exposing the playlist title on the RSS feed, we'll want to expose description and image url as well.