### PR TITLE
Store YoutubePlaylist description as TEXT

### DIFF
--- a/priv/repo/migrations/20190823002913_use_text_for_youtube_playlist_description.exs
+++ b/priv/repo/migrations/20190823002913_use_text_for_youtube_playlist_description.exs
@@ -1,0 +1,15 @@
+defmodule VidFeeder.Repo.Migrations.UseTextForYoutubePlaylistDescription do
+  use Ecto.Migration
+
+  def change do
+    alter table(:youtube_playlists) do
+      remove :description
+    end
+
+    flush()
+
+    alter table(:youtube_playlists) do
+      add :description, :text
+    end
+  end
+end


### PR DESCRIPTION
Currently we're storing description as a VARCHAR with a 255 char limit. We should use TEXT instead.