### PR TITLE
Fix distillery

### DIFF
--- a/rel/config.exs
+++ b/rel/config.exs
@@ -7,10 +7,10 @@
 |> Path.wildcard()
 |> Enum.map(&Code.eval_file(&1))
 
-use Mix.Releases.Config,
-    # This sets the default release built by `mix release`
+use Distillery.Releases.Config,
+    # This sets the default release built by `mix distillery.release`
     default_release: :default,
-    # This sets the default environment used by `mix release`
+    # This sets the default environment used by `mix distillery.release`
     default_environment: Mix.env()
 
 # For a full list of config options for both releases
@@ -43,7 +43,7 @@ end
 
 # You may define one or more releases in this file.
 # If you have not set a default release, or selected one
-# when running `mix release`, the first release in the file
+# when running `mix distillery.release`, the first release in the file
 # will be used by default
 
 release :vidfeeder do


### PR DESCRIPTION
When upgrading to 2.1 a few things changed to avoid colliding with the builtin `mix release` that shipped in 1.9:
* `mix release` is now `mix distillery.release`
* `Mix.Releases.Config` is now `Distillery.Releases.Config`