### PR TITLE
Bump gettext dependency

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -17,7 +17,7 @@
   "elixir_make": {:hex, :elixir_make, "0.6.0", "38349f3e29aff4864352084fc736fa7fa0f2995a819a737554f7ebd28b85aaab", [:mix], [], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.14.3", "d0c66f1c87faa301c1a85a809a3ee9097a4264b2edf7644bf5c123237ef732bf", [:mix], [], "hexpm"},
-  "gettext": {:hex, :gettext, "0.17.2", "c593ddfac45af1f7f4cd334151ab46fb426979e914a00361fe191903b0064c56", [:mix], [], "hexpm"},
+  "gettext": {:hex, :gettext, "0.17.4", "f13088e1ec10ce01665cf25f5ff779e7df3f2dc71b37084976cf89d1aa124d5c", [:mix], [], "hexpm"},
   "google_api_you_tube": {:hex, :google_api_you_tube, "0.1.0", "ab3b83df4a8afe6ec3ad17e322cbf65c89d8887582d8798881b5eb1269691ba5", [:mix], [{:google_gax, "~> 0.1.0", [hex: :google_gax, repo: "hexpm", optional: false]}], "hexpm"},
   "google_gax": {:hex, :google_gax, "0.1.3", "3455b58188803a554cc07447268af1da1cf35ca280267e297c677d005d1b2117", [:mix], [{:poison, ">= 1.0.0 and < 4.0.0", [hex: :poison, repo: "hexpm", optional: false]}, {:tesla, "~> 1.0", [hex: :tesla, repo: "hexpm", optional: false]}], "hexpm"},
   "goth": {:hex, :goth, "0.8.2", "edd1359f4e612266188a6837fcb562626403458398c6ba36d6f8c88a14075366", [:mix], [{:httpoison, "~> 0.11 or ~> 1.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:json_web_token, "~> 0.2.10", [hex: :json_web_token, repo: "hexpm", optional: false]}, {:poison, "~> 2.1 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Currently requests to `GET /rss/:id` are failing as `lgettext/4` is not defined:

```elixir
Timex.Gettext.lgettext("en", "weekdays", "Mon", %{})
```

See https://github.com/elixir-gettext/gettext/issues/236 for more information.