### PR TITLE
Refresh sources every hour

### DIFF
--- a/lib/vidfeeder/source_scheduler.ex
+++ b/lib/vidfeeder/source_scheduler.ex
@@ -50,7 +50,7 @@ defmodule VidFeeder.SourceScheduler do
       Repo.all(
         from(s in Source,
           where:
-            (s.last_refreshed_at <= datetime_add(^DateTime.utc_now(), -10, "minute") or
+            (s.last_refreshed_at <= datetime_add(^DateTime.utc_now(), -1, "hour") or
                is_nil(s.last_refreshed_at)) and s.state != "processing",
           limit: ^demand
         )


### PR DESCRIPTION
Currently we refresh sources every 10 minutes. We're now tracking enough feeds such that we're hitting our daily quota <12 hours into the day. While this might not be the only optimization we make, it's the easiest to make. So let's start with this.