### PR TITLE
Fix key error

### DIFF
--- a/lib/log_formatter.ex
+++ b/lib/log_formatter.ex
@@ -57,7 +57,7 @@ defmodule VidFeeder.LogFormatter do
           |> Poison.encode!()
         rescue
           Poison.EncodeError ->
-            encode!(%{payload | msg: inspect(payload.msg)})
+            encode!(%{payload | msg: inspect(payload.message)})
         end
 
       "#{json}\n"


### PR DESCRIPTION
Fixes a bug introduced in #62, which attempted to inspect the `payload.msg` on failed encoding. The actual attribute is `payload.message`.