### PR TITLE
Close temp youtube-dl file

### DIFF
--- a/lib/vidfeeder/youtube_dl_updater.ex
+++ b/lib/vidfeeder/youtube_dl_updater.ex
@@ -46,6 +46,8 @@ defmodule VidFeeder.YoutubeDlUpdater do
     Logger.debug("Got latest youtube-dl, writing to #{file_path}...")
 
     IO.binwrite(fd, data)
+    File.close(fd)
+
     File.chmod!(file_path, 0o755)
 
     file_path


### PR DESCRIPTION
* Apparently you can't execute binaries that are open for writing on linux.
  This wasn't an issue on macOS.